### PR TITLE
Sf analytics

### DIFF
--- a/Eventmain/serializers.py
+++ b/Eventmain/serializers.py
@@ -72,13 +72,13 @@ class BookingSerializer(serializers.ModelSerializer):
         ticket = data.get('ticket')
         quantity = data.get('quantity')
 
-        if quantity is None and quantity<= 0:
+        if quantity is None or quantity <= 0:
             raise serializers.ValidationError("Quantity must be a positive integer.")
 
-        # Calculate total booked quantity for this ticket
+        # Count both pending and paid bookings
         booked_quantity = Booking.objects.filter(
             ticket=ticket,
-            status='paid'  # Only count paid bookings
+            status__in=['pending', 'paid']
         ).aggregate(total=models.Sum('quantity'))['total'] or 0
 
         available_quantity = ticket.quantity - booked_quantity

--- a/Eventmain/views.py
+++ b/Eventmain/views.py
@@ -66,7 +66,6 @@ class EventViewSet(viewsets.ModelViewSet):
         if user.is_staff:
             return Event.objects.all()
         if hasattr(user, "organizer_profile"):
-        if hasattr(user, "organizer_profile"):
             return Event.objects.filter(organizer=user.organizer_profile)
         return Event.objects.none()
 
@@ -75,12 +74,10 @@ class EventViewSet(viewsets.ModelViewSet):
 
         # Make sure user has an organizer profile
         organizer = getattr(user, "organizer_profile", None)
-        organizer = getattr(user, "organizer_profile", None)
         if not organizer:
             raise PermissionDenied("You are not registered as an organizer.")
 
         # Check if the organizer is approved
-        if organizer.status.strip().lower() != "approved":
         if organizer.status.strip().lower() != "approved":
             raise PermissionDenied("Organizer is not approved to create events.")
 
@@ -94,7 +91,6 @@ class EventViewSet(viewsets.ModelViewSet):
         if event.organizer.user != user:
             raise PermissionDenied("You do not own this event.")
         if event.status not in ["draft", "cancelled"]:
-        if event.status not in ["draft", "cancelled"]:
             raise PermissionDenied("Event cannot be edited in its current state.")
 
         serializer.save()
@@ -105,7 +101,6 @@ class EventViewSet(viewsets.ModelViewSet):
 
         if event.organizer.user != user:
             raise PermissionDenied("You do not own this event.")
-        if event.status not in ["draft", "cancelled"]:
         if event.status not in ["draft", "cancelled"]:
             raise PermissionDenied("Event cannot be deleted in its current state.")
 

--- a/Eventmain/views.py
+++ b/Eventmain/views.py
@@ -9,15 +9,8 @@ from rest_framework.exceptions import PermissionDenied
 from .models import Event
 from .serializers import EventSerializer
 from rest_framework import viewsets
-from .models import (
-    Organizer, Event, Ticket, Booking, Media, AuditLog,
-    Notification, QRCode, EventAnalytics, EventReview
-)
-from .serializers import (
-    OrganizerSerializer, EventSerializer, TicketSerializer, BookingSerializer,
-    MediaSerializer, AuditLogSerializer, NotificationSerializer, QRCodeSerializer,
-    EventAnalyticsSerializer, EventReviewSerializer
-)
+from .models import *
+from .serializers import *
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework import status, permissions
@@ -39,7 +32,10 @@ class OrganizerViewSet(viewsets.ModelViewSet):
         organizer.status = "approved"
         organizer.verified_by = request.user
         organizer.save()
-        return Response({'detail': 'Organizer approved successfully.'}, status=status.HTTP_200_OK)
+        return Response(
+            {"detail": "Organizer approved successfully."}, status=status.HTTP_200_OK
+        )
+
 
 class EventViewSet(viewsets.ModelViewSet):
     queryset = Event.objects.all()

--- a/Eventmain/views.py
+++ b/Eventmain/views.py
@@ -221,3 +221,6 @@ class EventReviewViewSet(viewsets.ModelViewSet):
 
 def khalti_test_view(request):
     return render(request, "khalti_test.html")
+
+def khalti_test_view(request):
+    return render(request, 'khalti_test.html')

--- a/Eventmain/views.py
+++ b/Eventmain/views.py
@@ -1,10 +1,15 @@
 import requests
+import io
+import qrcode
+from django.core.files.base import ContentFile
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework import status, viewsets
+from rest_framework.permissions import IsAuthenticated
 from django.conf import settings
 from django.shortcuts import render
-from rest_framework.exceptions import ValidationError
 from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.exceptions import PermissionDenied
 from .models import Event
 from .serializers import EventSerializer
@@ -91,15 +96,6 @@ class EventViewSet(viewsets.ModelViewSet):
 class TicketViewSet(viewsets.ModelViewSet):
     queryset = Ticket.objects.all()
     serializer_class = TicketSerializer
-
-
-import io
-import qrcode
-from django.core.files.base import ContentFile
-from rest_framework.decorators import action
-from rest_framework.response import Response
-from rest_framework import status, viewsets
-from rest_framework.permissions import IsAuthenticated
 
 
 class BookingViewSet(viewsets.ModelViewSet):
@@ -222,5 +218,6 @@ class EventReviewViewSet(viewsets.ModelViewSet):
     queryset = EventReview.objects.all()
     serializer_class = EventReviewSerializer
 
+
 def khalti_test_view(request):
-    return render(request, 'khalti_test.html')
+    return render(request, "khalti_test.html")


### PR DESCRIPTION
Merge Updated booking validation to include both 'pending' and 'paid' statuses
  when calculating booked ticket quantity. from Sf_analytics to feature

## Summary by Sourcery

Integrate Khalti payment verification and refunds into the booking workflow, update validation to account for pending and paid bookings, and enforce authentication on payment-related endpoints

New Features:
- Add verify_payment action in BookingViewSet to verify payments with Khalti, update booking status, and generate a QR code
- Introduce refund_booking method in BookingViewSet to process refunds via Khalti

Enhancements:
- Update booking serializer validation to count both pending and paid statuses when calculating booked ticket quantities
- Require authentication for booking payment endpoints and include a test view for Khalti integration

Chores:
- Restructure imports and remove redundant code in views